### PR TITLE
Upgrade Boot to 1.5.10 but pin Lombok at 1.16.18

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -14,8 +14,8 @@
     <name>Subatomic domain implementation</name>
 
     <properties>
-        <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
-        <axon.version>3.1.2</axon.version>
+        <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
+        <axon.version>3.1.3</axon.version>
     </properties>
 
     <dependencyManagement>
@@ -75,6 +75,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <version>1.16.18</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Related to #39

**NOTE:** this does not close #39 but instead just a quick fix to get us onto the latest Spring Boot release and preparing for Spring Boot 2.0 releasing soon.