### PR TITLE
Fixed Bitbucket Key generation issues

### DIFF
--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
@@ -73,6 +73,7 @@ public class ProjectController {
                     .isNotBlank(request.getBitbucketProject().getName())) {
                 projectService.requestBitbucketProject(id,
                         request.getBitbucketProject().getName(),
+                        request.getBitbucketProject().getKey(),
                         request.getBitbucketProject().getDescription(),
                         request.getCreatedBy());
             }

--- a/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
@@ -69,7 +69,7 @@ public class ProjectService {
     }
 
     public String requestBitbucketProject(String projectId, String name,
-            String description, String requestedBy) {
+            String projectKey, String description, String requestedBy) {
         Set<TeamEntity> projectAssociatedTeams = findTeamsByProjectId(
                 projectId);
         Set<String> allMemberAndOwnerIds = getAllMemberAndOwnerIds(
@@ -80,6 +80,7 @@ public class ProjectService {
                         BitbucketProject.builder()
                                 .name(name)
                                 .description(description)
+                                .key(projectKey)
                                 .build(),
                         new TeamMemberId(requestedBy),
                         allMemberAndOwnerIds),

--- a/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
@@ -77,7 +77,6 @@ public class Project {
             key = bitbucketProject.getKey();
         }
 
-
         apply(new BitbucketProjectRequested(
                 new ProjectId(command.getProjectId()),
                 BitbucketProject.builder()

--- a/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
@@ -73,6 +73,10 @@ public class Project {
         // TODO check for duplicate keys
         BitbucketProject bitbucketProject = command.getBitbucketProject();
         String key = generateProjectKey(bitbucketProject.getName());
+        if (StringUtils.isNotBlank(bitbucketProject.getKey())) {
+            key = bitbucketProject.getKey();
+        }
+
 
         apply(new BitbucketProjectRequested(
                 new ProjectId(command.getProjectId()),


### PR DESCRIPTION
A project key can now be supplied with a bitbucket project request. If a key is not supplied, a new one is generated.

Resolves #49 