### PR TITLE
Fix link bitbucket project

### DIFF
--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
@@ -93,14 +93,12 @@ public class ProjectController {
                         request.getCreatedBy());
             }
         }
-
-        if (request.getProjectEnvironment() != null) {
+        else if (request.getTeams() != null){
+            projectService.linkProjectToTeams(id, request.getCreatedBy(), request.getTeams());
+        }
+        else if (request.getProjectEnvironment() != null) {
             projectService.newProjectEnvironment(id,
                     request.getProjectEnvironment().getRequestedBy());
-        }
-
-        if (request.getTeams() != null){
-            projectService.linkProjectToTeams(id, request.getCreatedBy(), request.getTeams());
         }
 
         return ResponseEntity.accepted()

--- a/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/domain/project/Project.java
@@ -201,7 +201,7 @@ public class Project {
             }
         }
 
-        if (unlinkedTeams.size() == 0){
+        if (unlinkedTeams.isEmpty()){
             throw new InvalidRequestException("There are no teams that are not already associated to this project");
         }
 


### PR DESCRIPTION
Added early escape so that link project to teams does not get run when trying to link a bitbucket project to a gluon project.

Resolves #75