### PR TITLE
Fix error when requesting new project environments.

### DIFF
--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
@@ -93,7 +93,7 @@ public class ProjectController {
                         request.getCreatedBy());
             }
         }
-        else if (request.getTeams() != null){
+        else if (!request.getTeams().isEmpty()){
             projectService.linkProjectToTeams(id, request.getCreatedBy(), request.getTeams());
         }
         else if (request.getProjectEnvironment() != null) {


### PR DESCRIPTION
Team array will never be null. Check should be for empty.

Resolve #77