### PR TITLE
Increase the openshift resource column size

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -14,7 +14,7 @@
     <name>Subatomic domain implementation</name>
 
     <properties>
-        <spring.boot.version>1.5.10.RELEASE</spring.boot.version>
+        <spring.boot.version>2.1.2.RELEASE</spring.boot.version>
     </properties>
 
     <dependencyManagement>

--- a/nucleus/src/main/java/za/co/absa/subatomic/application/openshift/OpenShiftResourceService.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/application/openshift/OpenShiftResourceService.java
@@ -37,7 +37,7 @@ public class OpenShiftResourceService {
                             .build());
         }
 
-        return this.openShiftResourceRepository.save(openShiftResourceEntities);
+        return this.openShiftResourceRepository.saveAll(openShiftResourceEntities);
     }
 
     @Transactional(readOnly = true)

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/openshift/view/jpa/OpenShiftResourceEntity.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/openshift/view/jpa/OpenShiftResourceEntity.java
@@ -5,6 +5,7 @@ import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.Table;
 
 import lombok.AccessLevel;
@@ -34,6 +35,7 @@ public class OpenShiftResourceEntity {
     private String name;
 
     @Convert(converter = EncryptedAttributeConverter.class)
-    @Column(length = 65535)
+    @Lob
+    @Column(columnDefinition="CLOB")
     private String resourceDetails;
 }

--- a/nucleus/src/main/resources/application.yml
+++ b/nucleus/src/main/resources/application.yml
@@ -15,8 +15,8 @@ spring:
       enabled: true
       path: /h2-console
   data.rest.detection-strategy: visibility
-flyway:
-  enabled: true
+  flyway:
+    enabled: true
 gluon:
   encryption:
     encryptionKey: "REPLACE_THIS"

--- a/nucleus/src/main/resources/db/migration/V1_9__change_openshift_resource_definition.sql
+++ b/nucleus/src/main/resources/db/migration/V1_9__change_openshift_resource_definition.sql
@@ -1,0 +1,1 @@
+alter table open_shift_resources alter column resource_details type clob;


### PR DESCRIPTION
Changed openshift resource details type to CLOB to allow bigger resource definitions.
Required moving to spring 2.

Closes #157