### PR TITLE
Pipeline modification functionality

### DIFF
--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -119,6 +119,11 @@
             <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.21.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/nucleus/pom.xml
+++ b/nucleus/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>jaxb-impl</artifactId>
             <version>2.2.11</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>
@@ -109,9 +114,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/DeploymentPipelineResourceAssembler.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/DeploymentPipelineResourceAssembler.java
@@ -16,8 +16,12 @@ public class DeploymentPipelineResourceAssembler {
 
         List<DeploymentEnvironmentResource> environments = new ArrayList<>();
 
-        for (DeploymentEnvironment environment : pipeline.getEnvironments()) {
-            environments.add(this.toDeploymentEnvironmentResource(environment));
+        if (pipeline.getEnvironments() != null) {
+            for (DeploymentEnvironment environment : pipeline
+                    .getEnvironments()) {
+                environments
+                        .add(this.toDeploymentEnvironmentResource(environment));
+            }
         }
 
         deploymentPipelineResource.setEnvironments(environments);

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectController.java
@@ -86,6 +86,14 @@ public class ProjectController {
             projectService.newProjectEnvironment(id,
                     request.getProjectEnvironment().getRequestedBy());
         }
+        if (request.getDevDeploymentPipeline() != null) {
+            projectService.updateDevDeploymentPipeline(id,
+                    request.getCreatedBy(), request.getDevDeploymentPipeline());
+        }
+        if (request.getReleaseDeploymentPipelines() != null) {
+            projectService.updateReleaseDeploymentPipelines(id,
+                    request.getCreatedBy(), request.getReleaseDeploymentPipelines());
+        }
 
         return ResponseEntity.accepted()
                 .body(assembler.toResource(projectService

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectResource.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/project/rest/ProjectResource.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import za.co.absa.subatomic.adapter.team.rest.TeamResourceBase;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -17,9 +18,9 @@ public class ProjectResource extends ProjectResourceBase {
 
     private BitbucketProjectResource bitbucketProject;
 
-    private TeamResource owningTeam;
+    private TeamResourceBase owningTeam;
 
-    private List<TeamResource> teams = new ArrayList<>();
+    private List<TeamResourceBase> teams = new ArrayList<>();
 
     private ProjectEnvironment projectEnvironment;
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResource.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResource.java
@@ -1,36 +1,19 @@
 package za.co.absa.subatomic.adapter.team.rest;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-
-import org.springframework.hateoas.ResourceSupport;
 
 import lombok.Data;
 import za.co.absa.subatomic.adapter.member.rest.TeamMemberResourceBase;
 
 @Data
-public class TeamResource extends ResourceSupport {
-
-    private String teamId;
-
-    private String name;
-
-    private String description;
-
-    private String openShiftCloud;
-
-    private Date createdAt;
-
-    private String createdBy;
+public class TeamResource extends TeamResourceBase {
 
     private final List<TeamMemberResourceBase> members = new ArrayList<>();
 
     private final List<TeamMemberResourceBase> owners = new ArrayList<>();
 
     private final List<MembershipRequestResource> membershipRequests = new ArrayList<>();
-
-    private Slack slack;
 
     private DevOpsEnvironment devOpsEnvironment;
 }

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBase.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBase.java
@@ -1,0 +1,25 @@
+package za.co.absa.subatomic.adapter.team.rest;
+
+import java.util.Date;
+
+import org.springframework.hateoas.ResourceSupport;
+
+import lombok.Data;
+
+@Data
+public class TeamResourceBase extends ResourceSupport {
+
+    private String teamId;
+
+    private String name;
+
+    private String description;
+
+    private String openShiftCloud;
+
+    private Date createdAt;
+
+    private String createdBy;
+
+    private Slack slack;
+}

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssembler.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssembler.java
@@ -1,0 +1,39 @@
+package za.co.absa.subatomic.adapter.team.rest;
+
+import static java.util.Optional.ofNullable;
+
+import org.springframework.hateoas.mvc.ResourceAssemblerSupport;
+
+import za.co.absa.subatomic.infrastructure.team.view.jpa.TeamEntity;
+
+public class TeamResourceBaseAssembler
+        extends ResourceAssemblerSupport<TeamEntity, TeamResourceBase> {
+
+    public TeamResourceBaseAssembler() {
+        super(TeamController.class, TeamResourceBase.class);
+    }
+
+    @Override
+    public TeamResourceBase toResource(TeamEntity entity) {
+        if (entity != null) {
+            TeamResourceBase resource = createResourceWithId(entity.getTeamId(),
+                    entity);
+            resource.setTeamId(entity.getTeamId());
+            resource.setName(entity.getName());
+            resource.setDescription(entity.getDescription());
+            resource.setOpenShiftCloud(entity.getOpenShiftCloud());
+            resource.setCreatedAt(entity.getCreatedAt());
+            resource.setCreatedBy(entity.getCreatedBy().getMemberId());
+
+            ofNullable(entity.getSlackDetails())
+                    .ifPresent(slackDetails -> resource
+                            .setSlack(
+                                    new Slack(slackDetails
+                                            .getTeamChannel())));
+            return resource;
+        }
+        else {
+            return null;
+        }
+    }
+}

--- a/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import za.co.absa.subatomic.adapter.project.rest.ProjectResource;
-import za.co.absa.subatomic.adapter.project.rest.TeamResource;
+import za.co.absa.subatomic.adapter.team.rest.TeamResourceBase;
 import za.co.absa.subatomic.application.member.TeamMemberService;
 import za.co.absa.subatomic.application.team.TeamAssertions;
 import za.co.absa.subatomic.application.tenant.TenantService;
@@ -147,7 +147,7 @@ public class ProjectService {
     }
 
     public String linkProjectToTeams(String projectId, String actionedBy,
-            List<TeamResource> teamsToLink) {
+            List<TeamResourceBase> teamsToLink) {
         TeamMemberEntity actionedByEntity = teamMemberService
                 .getTeamMemberPersistenceHandler()
                 .findByTeamMemberId(actionedBy);
@@ -156,7 +156,7 @@ public class ProjectService {
 
         List<TeamEntity> teamEntitiesToLink = new ArrayList<>();
 
-        for (TeamResource team : teamsToLink) {
+        for (TeamResourceBase team : teamsToLink) {
             teamEntitiesToLink
                     .add(teamPersistenceHandler.findByTeamId(team.getTeamId()));
         }
@@ -181,12 +181,14 @@ public class ProjectService {
 
     }
 
-    public void updateReleaseDeploymentPipelines(String projectId, String actionedBy,
-                                            List<? extends DeploymentPipeline> deploymentPipelines) {
+    public void updateReleaseDeploymentPipelines(String projectId,
+            String actionedBy,
+            List<? extends DeploymentPipeline> deploymentPipelines) {
 
         assertMemberBelongsToAnAssociatedTeam(projectId, actionedBy);
 
-        this.projectPersistenceHandler.updateReleaseDeploymentPipelines(projectId,
+        this.projectPersistenceHandler.updateReleaseDeploymentPipelines(
+                projectId,
                 deploymentPipelines);
 
     }

--- a/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/application/project/ProjectService.java
@@ -16,6 +16,7 @@ import za.co.absa.subatomic.domain.exception.ApplicationAuthorisationException;
 import za.co.absa.subatomic.domain.exception.DuplicateRequestException;
 import za.co.absa.subatomic.domain.exception.InvalidRequestException;
 import za.co.absa.subatomic.domain.project.BitbucketProject;
+import za.co.absa.subatomic.domain.project.DeploymentPipeline;
 import za.co.absa.subatomic.infrastructure.member.view.jpa.TeamMemberEntity;
 import za.co.absa.subatomic.infrastructure.project.ProjectAutomationHandler;
 import za.co.absa.subatomic.infrastructure.project.view.jpa.ProjectEntity;
@@ -168,6 +169,26 @@ public class ProjectService {
                 actionedByEntity, teamEntitiesToLink);
 
         return projectEntity.getProjectId();
+    }
+
+    public void updateDevDeploymentPipeline(String projectId, String actionedBy,
+            DeploymentPipeline deploymentPipeline) {
+
+        assertMemberBelongsToAnAssociatedTeam(projectId, actionedBy);
+
+        this.projectPersistenceHandler.updateDevDeploymentPipeline(projectId,
+                deploymentPipeline);
+
+    }
+
+    public void updateReleaseDeploymentPipelines(String projectId, String actionedBy,
+                                            List<? extends DeploymentPipeline> deploymentPipelines) {
+
+        assertMemberBelongsToAnAssociatedTeam(projectId, actionedBy);
+
+        this.projectPersistenceHandler.updateReleaseDeploymentPipelines(projectId,
+                deploymentPipelines);
+
     }
 
     public void deleteProject(String projectId) {

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapper.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapper.java
@@ -64,7 +64,8 @@ public class AtomistProjectMapper {
                 .projectId(projectEntity.getProjectId())
                 .name(projectEntity.getName())
                 .description(projectEntity.getDescription())
-                .createdBy(new TeamMemberId(projectEntity.getProjectId()))
+                .createdBy(new TeamMemberId(
+                        projectEntity.getCreatedBy().getMemberId()))
                 .team(new TeamId(projectEntity.getOwningTeam().getTeamId()))
                 .tenant(new TenantId(
                         projectEntity.getOwningTenant().getTenantId()))
@@ -81,7 +82,8 @@ public class AtomistProjectMapper {
                 .projectId(projectEntity.getProjectId())
                 .name(projectEntity.getName())
                 .description(projectEntity.getDescription())
-                .createdBy(new TeamMemberId(projectEntity.getProjectId()))
+                .createdBy(new TeamMemberId(
+                        projectEntity.getCreatedBy().getMemberId()))
                 .team(new TeamId(projectEntity.getOwningTeam().getTeamId()))
                 .tenant(new TenantId(
                         projectEntity.getOwningTenant().getTenantId()))

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapper.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapper.java
@@ -26,9 +26,13 @@ public class AtomistProjectMapper {
 
         List<AtomistDeploymentEnvironment> environments = new ArrayList<>();
 
-        for (DeploymentEnvironment environment : pipeline.getEnvironments()) {
-            environments
-                    .add(this.createAtomistDeploymentEnvironment(environment));
+        if (pipeline.getEnvironments() != null) {
+            for (DeploymentEnvironment environment : pipeline
+                    .getEnvironments()) {
+                environments
+                        .add(this.createAtomistDeploymentEnvironment(
+                                environment));
+            }
         }
 
         return new AtomistDeploymentPipeline.Builder()
@@ -48,10 +52,12 @@ public class AtomistProjectMapper {
 
         List<AtomistDeploymentPipeline> releaseDeploymentPipelines = new ArrayList<>();
 
-        for (DeploymentPipeline pipeline : projectEntity
-                .getReleaseDeploymentPipelines()) {
-            releaseDeploymentPipelines
-                    .add(this.createAtomistDeploymentPipeline(pipeline));
+        if (projectEntity.getReleaseDeploymentPipelines() != null) {
+            for (DeploymentPipeline pipeline : projectEntity
+                    .getReleaseDeploymentPipelines()) {
+                releaseDeploymentPipelines
+                        .add(this.createAtomistDeploymentPipeline(pipeline));
+            }
         }
 
         return new AtomistProject.Builder()

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/project/view/jpa/DevDeploymentEnvironmentEntity.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/project/view/jpa/DevDeploymentEnvironmentEntity.java
@@ -26,7 +26,7 @@ import za.co.absa.subatomic.domain.project.DeploymentEnvironment;
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Setter(value = AccessLevel.PACKAGE)
 @Getter
-class DevDeploymentEnvironmentEntity implements DeploymentEnvironment {
+public class DevDeploymentEnvironmentEntity implements DeploymentEnvironment {
 
     @Id
     @GeneratedValue

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/project/view/jpa/ReleaseDeploymentEnvironmentEntity.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/project/view/jpa/ReleaseDeploymentEnvironmentEntity.java
@@ -26,7 +26,7 @@ import za.co.absa.subatomic.domain.project.DeploymentEnvironment;
 @NoArgsConstructor(access = AccessLevel.PACKAGE)
 @Setter(value = AccessLevel.PACKAGE)
 @Getter
-class ReleaseDeploymentEnvironmentEntity
+public class ReleaseDeploymentEnvironmentEntity
         implements DeploymentEnvironment {
 
     @Id

--- a/nucleus/src/test/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssemblerTest.java
+++ b/nucleus/src/test/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssemblerTest.java
@@ -1,0 +1,68 @@
+package za.co.absa.subatomic.adapter.team.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import za.co.absa.subatomic.infrastructure.member.view.jpa.SlackDetailsEmbedded;
+import za.co.absa.subatomic.infrastructure.member.view.jpa.TeamMemberEntity;
+import za.co.absa.subatomic.infrastructure.team.view.jpa.TeamEntity;
+
+public class TeamResourceBaseAssemblerTest {
+    @Test
+    public void toResourceWithFullEntityShouldReturnResource()
+            throws Exception {
+        TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
+                .firstName("Kieran").lastName("Bristow")
+                .domainUsername("username").email("kieran@mail.com")
+                .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
+        TeamEntity entity = TeamEntity.builder().id(1L).description("A Team")
+                .name("Team").teamId("1235").createdBy(member)
+                .openShiftCloud("cloud-name")
+                .slackDetails(
+                        new za.co.absa.subatomic.infrastructure.team.view.jpa.SlackDetailsEmbedded(
+                                "channel"))
+                .owners(Collections.singleton(member)).build();
+
+        TeamResourceBaseAssembler assembler = new TeamResourceBaseAssembler();
+
+        TeamResourceBase teamResourceBase = assembler.toResource(entity);
+
+        assertThat(teamResourceBase.getName()).isEqualTo("Team");
+        assertThat(teamResourceBase.getDescription()).isEqualTo("A Team");
+        assertThat(teamResourceBase.getTeamId()).isEqualTo("1235");
+        assertThat(teamResourceBase.getCreatedBy()).isEqualTo("1234");
+        assertThat(teamResourceBase.getOpenShiftCloud())
+                .isEqualTo("cloud-name");
+        assertThat(teamResourceBase.getSlack().getTeamChannel())
+                .isEqualTo("channel");
+    }
+
+    @Test
+    public void toResourceWithEntityWithNoSlackShouldReturnResource()
+            throws Exception {
+        TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
+                .firstName("Kieran").lastName("Bristow")
+                .domainUsername("username").email("kieran@mail.com")
+                .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
+        TeamEntity entity = TeamEntity.builder().id(1L).description("A Team")
+                .name("Team").teamId("1235").createdBy(member)
+                .openShiftCloud("cloud-name")
+                .owners(Collections.singleton(member)).build();
+
+        TeamResourceBaseAssembler assembler = new TeamResourceBaseAssembler();
+
+        TeamResourceBase teamResourceBase = assembler.toResource(entity);
+
+        assertThat(teamResourceBase.getName()).isEqualTo("Team");
+        assertThat(teamResourceBase.getDescription()).isEqualTo("A Team");
+        assertThat(teamResourceBase.getTeamId()).isEqualTo("1235");
+        assertThat(teamResourceBase.getCreatedBy()).isEqualTo("1234");
+        assertThat(teamResourceBase.getOpenShiftCloud())
+                .isEqualTo("cloud-name");
+        assertThat(teamResourceBase.getSlack())
+                .isEqualTo(null);
+    }
+}

--- a/nucleus/src/test/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssemblerTest.java
+++ b/nucleus/src/test/java/za/co/absa/subatomic/adapter/team/rest/TeamResourceBaseAssemblerTest.java
@@ -12,13 +12,13 @@ import za.co.absa.subatomic.infrastructure.team.view.jpa.TeamEntity;
 
 public class TeamResourceBaseAssemblerTest {
     @Test
-    public void toResourceWithFullEntityShouldReturnResource()
+    public void whenToResourceWithFullEntity_thenReturnResource()
             throws Exception {
         TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
                 .firstName("Kieran").lastName("Bristow")
                 .domainUsername("username").email("kieran@mail.com")
                 .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
-        TeamEntity entity = TeamEntity.builder().id(1L).description("A Team")
+        TeamEntity entity = TeamEntity.builder().description("A Team")
                 .name("Team").teamId("1235").createdBy(member)
                 .openShiftCloud("cloud-name")
                 .slackDetails(
@@ -41,7 +41,7 @@ public class TeamResourceBaseAssemblerTest {
     }
 
     @Test
-    public void toResourceWithEntityWithNoSlackShouldReturnResource()
+    public void whenToResourceWithEntityAndNoSlack_thenReturnResource()
             throws Exception {
         TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
                 .firstName("Kieran").lastName("Bristow")
@@ -64,5 +64,16 @@ public class TeamResourceBaseAssemblerTest {
                 .isEqualTo("cloud-name");
         assertThat(teamResourceBase.getSlack())
                 .isEqualTo(null);
+    }
+
+    @Test
+    public void whenToResourceWithNullEntity_thenReturnNull()
+            throws Exception {
+
+        TeamResourceBaseAssembler assembler = new TeamResourceBaseAssembler();
+
+        TeamResourceBase teamResourceBase = assembler.toResource(null);
+
+        assertThat(teamResourceBase).isEqualTo(null);
     }
 }

--- a/nucleus/src/test/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapperTest.java
+++ b/nucleus/src/test/java/za/co/absa/subatomic/infrastructure/atomist/resource/project/AtomistProjectMapperTest.java
@@ -1,0 +1,307 @@
+package za.co.absa.subatomic.infrastructure.atomist.resource.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import za.co.absa.subatomic.infrastructure.member.view.jpa.SlackDetailsEmbedded;
+import za.co.absa.subatomic.infrastructure.member.view.jpa.TeamMemberEntity;
+import za.co.absa.subatomic.infrastructure.project.view.jpa.DevDeploymentEnvironmentEntity;
+import za.co.absa.subatomic.infrastructure.project.view.jpa.DevDeploymentPipelineEntity;
+import za.co.absa.subatomic.infrastructure.project.view.jpa.ProjectEntity;
+import za.co.absa.subatomic.infrastructure.project.view.jpa.ReleaseDeploymentEnvironmentEntity;
+import za.co.absa.subatomic.infrastructure.project.view.jpa.ReleaseDeploymentPipelineEntity;
+import za.co.absa.subatomic.infrastructure.team.view.jpa.TeamEntity;
+import za.co.absa.subatomic.infrastructure.tenant.view.jpa.TenantEntity;
+
+public class AtomistProjectMapperTest {
+
+    @Test
+    public void whenCreateAtomistDeploymentEnvironmentWithValidDeploymentEnvironment_thenReturnCorrectTransformation()
+            throws Exception {
+        DevDeploymentEnvironmentEntity deploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Env")
+                .positionInPipeline(1)
+                .postfix("uat").build();
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+
+        AtomistDeploymentEnvironment atomistDeploymentEnvironment = projectMapper
+                .createAtomistDeploymentEnvironment(
+                        deploymentEnvironmentEntity);
+
+        assertThat(atomistDeploymentEnvironment.getDisplayName())
+                .isEqualTo("Env");
+        assertThat(atomistDeploymentEnvironment.getPostfix())
+                .isEqualTo("uat");
+        assertThat(atomistDeploymentEnvironment.getPositionInPipeline())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void whenCreateAtomistDeploymentPipelineWithValidDeploymentPipelineAndDefinedEnvironments_thenReturnCorrectTransformation()
+            throws Exception {
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+        DevDeploymentEnvironmentEntity uatDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(2)
+                .postfix("uat").build();
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        deploymentPipelineEntity.getEnvironments()
+                .add(uatDeploymentEnvironmentEntity);
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+
+        AtomistDeploymentPipeline atomistDeploymentPipeline = projectMapper
+                .createAtomistDeploymentPipeline(
+                        deploymentPipelineEntity);
+
+        assertThat(atomistDeploymentPipeline.getName())
+                .isEqualTo("some pipeline");
+        assertThat(atomistDeploymentPipeline.getPipelineId()).isEqualTo("1");
+        assertThat(atomistDeploymentPipeline.getTag()).isEqualTo("");
+        assertThat(
+                atomistDeploymentPipeline.getEnvironments().get(0).getPostfix())
+                        .isEqualTo("dev");
+        assertThat(
+                atomistDeploymentPipeline.getEnvironments().get(1).getPostfix())
+                        .isEqualTo("uat");
+
+    }
+
+    @Test
+    public void whenCreateAtomistDeploymentPipelineWithValidDeploymentPipelineAndNoEnvironments_thenReturnCorrectTransformation()
+            throws Exception {
+        ReleaseDeploymentPipelineEntity deploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+
+        AtomistDeploymentPipeline atomistDeploymentPipeline = projectMapper
+                .createAtomistDeploymentPipeline(
+                        deploymentPipelineEntity);
+
+        assertThat(atomistDeploymentPipeline.getName())
+                .isEqualTo("some pipeline");
+        assertThat(atomistDeploymentPipeline.getPipelineId()).isEqualTo("1");
+        assertThat(atomistDeploymentPipeline.getTag()).isEqualTo("tag");
+        assertThat(
+                atomistDeploymentPipeline.getEnvironments().size())
+                        .isEqualTo(0);
+
+    }
+
+    @Test
+    public void whenCreateAtomistProjectWithProjectEntityAndNoReleasePipelines_thenReturnCorrectTransform() {
+        TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
+                .firstName("Kieran").lastName("Bristow")
+                .domainUsername("username").email("kieran@mail.com")
+                .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
+        TeamEntity team = TeamEntity.builder().description("A Team")
+                .name("Team").teamId("1235").createdBy(member)
+                .openShiftCloud("cloud-name")
+                .owners(Collections.singleton(member)).build();
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+        DevDeploymentEnvironmentEntity uatDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(2)
+                .postfix("uat").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        deploymentPipelineEntity.getEnvironments()
+                .add(uatDeploymentEnvironmentEntity);
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .createdBy(member)
+                .description("a project").name("Project 1")
+                .owningTeam(team)
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+        AtomistProject atomistProject = projectMapper
+                .createAtomistProject(projectEntity);
+
+        assertThat(atomistProject.getName()).isEqualTo("Project 1");
+        assertThat(atomistProject.getDescription()).isEqualTo("a project");
+        assertThat(atomistProject.getProjectId()).isEqualTo("1");
+        assertThat(atomistProject.getTeam().getTeamId()).isEqualTo("1235");
+        assertThat(atomistProject.getDevDeploymentPipeline().getName())
+                .isEqualTo("some pipeline");
+        assertThat(atomistProject.getReleaseDeploymentPipelines().size())
+                .isEqualTo(0);
+        assertThat(atomistProject.getTenant().getTenantId()).isEqualTo("2");
+        assertThat(atomistProject.getCreatedBy().getTeamMemberId())
+                .isEqualTo("1234");
+    }
+
+    @Test
+    public void whenCreateAtomistProjectWithProjectEntityAndReleasePipelines_thenReturnCorrectTransform() {
+        TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
+                .firstName("Kieran").lastName("Bristow")
+                .domainUsername("username").email("kieran@mail.com")
+                .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
+        TeamEntity team = TeamEntity.builder().description("A Team")
+                .name("Team").teamId("1235").createdBy(member)
+                .openShiftCloud("cloud-name")
+                .owners(Collections.singleton(member)).build();
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("Dev Pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity releaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat").build();
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(releaseDeploymentEnvironmentEntity);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .createdBy(member)
+                .description("a project").name("Project 1")
+                .owningTeam(team)
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(Collections
+                        .singletonList(releaseDeploymentPipelineEntity))
+                .build();
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+        AtomistProject atomistProject = projectMapper
+                .createAtomistProject(projectEntity);
+
+        assertThat(atomistProject.getName()).isEqualTo("Project 1");
+        assertThat(atomistProject.getDescription()).isEqualTo("a project");
+        assertThat(atomistProject.getProjectId()).isEqualTo("1");
+        assertThat(atomistProject.getTeam().getTeamId()).isEqualTo("1235");
+        assertThat(atomistProject.getDevDeploymentPipeline().getName())
+                .isEqualTo("Dev Pipeline");
+        assertThat(
+                atomistProject.getReleaseDeploymentPipelines().get(0).getName())
+                        .isEqualTo("some pipeline");
+        assertThat(
+                atomistProject.getReleaseDeploymentPipelines().get(0)
+                        .getEnvironments().get(0).getDisplayName())
+                                .isEqualTo("UAT");
+        assertThat(atomistProject.getTenant().getTenantId()).isEqualTo("2");
+        assertThat(atomistProject.getCreatedBy().getTeamMemberId())
+                .isEqualTo("1234");
+    }
+
+    @Test
+    public void whenCreateAtomistProjectBaseWithSimpleProjectEntity_thenReturnCorrectTransform() {
+        TeamMemberEntity member = TeamMemberEntity.builder().memberId("1234")
+                .firstName("Kieran").lastName("Bristow")
+                .domainUsername("username").email("kieran@mail.com")
+                .slackDetails(new SlackDetailsEmbedded("kb", "kb2")).build();
+        TeamEntity team = TeamEntity.builder().description("A Team")
+                .name("Team").teamId("1235").createdBy(member)
+                .openShiftCloud("cloud-name")
+                .owners(Collections.singleton(member)).build();
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .createdBy(member)
+                .description("a project").name("Project 1")
+                .owningTeam(team)
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+
+        AtomistProjectMapper projectMapper = new AtomistProjectMapper();
+        AtomistProjectBase atomistProject = projectMapper
+                .createAtomistProjectBase(projectEntity);
+
+        assertThat(atomistProject.getName()).isEqualTo("Project 1");
+        assertThat(atomistProject.getDescription()).isEqualTo("a project");
+        assertThat(atomistProject.getProjectId()).isEqualTo("1");
+        assertThat(atomistProject.getTeam().getTeamId()).isEqualTo("1235");
+        assertThat(atomistProject.getTenant().getTenantId()).isEqualTo("2");
+        assertThat(atomistProject.getCreatedBy().getTeamMemberId())
+                .isEqualTo("1234");
+    }
+}

--- a/nucleus/src/test/java/za/co/absa/subatomic/infrastructure/project/view/jpa/ProjectPersistenceHandlerTest.java
+++ b/nucleus/src/test/java/za/co/absa/subatomic/infrastructure/project/view/jpa/ProjectPersistenceHandlerTest.java
@@ -1,0 +1,663 @@
+package za.co.absa.subatomic.infrastructure.project.view.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import za.co.absa.subatomic.infrastructure.tenant.view.jpa.TenantEntity;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+public class ProjectPersistenceHandlerTest {
+
+    @MockBean
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private ProjectPersistenceHandler projectPersistenceHandler;
+
+    @Test
+    public void whenUpdateDevDeploymentPipelineWithNewEnvironments_thenNewEnvironmentsAreAddedToPipeline() {
+
+        // Set up initial Project Entity
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new dev deployment pipeline
+        DevDeploymentPipelineEntity updatedDeploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity updatedDevDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(updatedDeploymentPipelineEntity)
+                .postfix("dev").build();
+        DevDeploymentEnvironmentEntity updatedUatDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(updatedDeploymentPipelineEntity)
+                .postfix("uat").build();
+        updatedDeploymentPipelineEntity.getEnvironments()
+                .add(updatedDevDeploymentEnvironmentEntity);
+        updatedDeploymentPipelineEntity.getEnvironments()
+                .add(updatedUatDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateDevDeploymentPipeline("1",
+                        updatedDeploymentPipelineEntity);
+
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .size()).isEqualTo(2);
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(1).getDisplayName()).isEqualTo("UAT");
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(1).getPositionInPipeline()).isEqualTo(2);
+    }
+
+    @Test
+    public void whenUpdateDevDeploymentPipelineWithUpdatedEnvironments_thenOldEnvironmentsAreUpdated() {
+
+        // Set up initial Project Entity
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new dev deployment pipeline
+        DevDeploymentPipelineEntity updatedDeploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity updatedDevDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev New")
+                .pipeline(updatedDeploymentPipelineEntity)
+                .postfix("dev").build();
+        updatedDeploymentPipelineEntity.getEnvironments()
+                .add(updatedDevDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateDevDeploymentPipeline("1",
+                        updatedDeploymentPipelineEntity);
+
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("Dev New");
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenUpdateDevDeploymentPipelineWithRemovedEnvironments_thenOldExcludedEnvironmentsAreRemoved() {
+
+        // Set up initial Project Entity
+        DevDeploymentPipelineEntity deploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity devDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Dev")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("dev").build();
+
+        DevDeploymentEnvironmentEntity uatDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(deploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat").build();
+
+        deploymentPipelineEntity.getEnvironments()
+                .add(devDeploymentEnvironmentEntity);
+        deploymentPipelineEntity.getEnvironments()
+                .add(uatDeploymentEnvironmentEntity);
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .devDeploymentPipeline(deploymentPipelineEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new dev deployment pipeline
+        DevDeploymentPipelineEntity updatedDeploymentPipelineEntity = DevDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .build();
+        DevDeploymentEnvironmentEntity updatedUatDeploymentEnvironmentEntity = DevDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(updatedDeploymentPipelineEntity)
+                .postfix("uat").build();
+        updatedDeploymentPipelineEntity.getEnvironments()
+                .add(updatedUatDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateDevDeploymentPipeline("1",
+                        updatedDeploymentPipelineEntity);
+
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT");
+        assertThat(updatedProject.getDevDeploymentPipeline().getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenUpdateReleaseDeploymentPipelinesWithNewEnvironments_thenPipelineIsUpdatedWithNewEnvironments() {
+
+        // Set up initial Project Entity
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity releaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat").build();
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(releaseDeploymentEnvironmentEntity);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity);
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new release deployment pipeline
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedUatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .postfix("uat").build();
+        ReleaseDeploymentEnvironmentEntity updatedPreProdReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Pre Prod")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .postfix("pre-prod").build();
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedUatReleaseDeploymentEnvironmentEntity);
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedPreProdReleaseDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateReleaseDeploymentPipelines("1",
+                        Collections.singletonList(
+                                updatedReleaseDeploymentPipelineEntity));
+
+        assertThat(updatedProject.getReleaseDeploymentPipelines()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .size()).isEqualTo(2);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(1).getDisplayName()).isEqualTo("Pre Prod");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(1).getPositionInPipeline()).isEqualTo(2);
+    }
+
+    @Test
+    public void whenUpdateReleaseDeploymentPipelinesWithUpdatedEnvironments_thenOldEnvironmentsAreUpdated() {
+
+        // Set up initial Project Entity
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity releaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat").build();
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(releaseDeploymentEnvironmentEntity);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity);
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new release deployment pipeline
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT New")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .postfix("uat").build();
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedReleaseDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateReleaseDeploymentPipelines("1",
+                        Collections.singletonList(
+                                updatedReleaseDeploymentPipelineEntity));
+
+        assertThat(updatedProject.getReleaseDeploymentPipelines()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT New");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenUpdateReleaseDeploymentPipelinesWithRemovedEnvironments_thenOldExcludedEnvironments() {
+
+        // Set up initial Project Entity
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity uatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat").build();
+        ReleaseDeploymentEnvironmentEntity preprodReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Pre Prod")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("pre-prod").build();
+
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(uatReleaseDeploymentEnvironmentEntity);
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(preprodReleaseDeploymentEnvironmentEntity);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity);
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new release deployment pipeline
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("Pre Prod")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .postfix("pre-prod").build();
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedReleaseDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateReleaseDeploymentPipelines("1",
+                        Collections.singletonList(
+                                updatedReleaseDeploymentPipelineEntity));
+
+        assertThat(updatedProject.getReleaseDeploymentPipelines()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("Pre Prod");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenUpdateReleaseDeploymentPipelinesWithNewPipeline_thenAddNewPipeline() {
+
+        // Set up initial Project Entity
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity uatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT1")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat1").build();
+
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(uatReleaseDeploymentEnvironmentEntity);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity);
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new release deployment pipeline
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedUatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT1")
+                .pipeline(updatedReleaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat1").build();
+
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedUatReleaseDeploymentEnvironmentEntity);
+
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity2 = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("2")
+                .environments(new ArrayList<>())
+                .name("some pipeline 2")
+                .tag("tag 2")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedUatReleaseDeploymentEnvironmentEntity2 = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT2")
+                .pipeline(updatedReleaseDeploymentPipelineEntity2)
+                .positionInPipeline(1)
+                .postfix("uat2").build();
+
+        updatedReleaseDeploymentPipelineEntity2.getEnvironments()
+                .add(updatedUatReleaseDeploymentEnvironmentEntity2);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateReleaseDeploymentPipelines("1",
+                        Arrays.asList(
+                                updatedReleaseDeploymentPipelineEntity,
+                                updatedReleaseDeploymentPipelineEntity2));
+
+        assertThat(updatedProject.getReleaseDeploymentPipelines()
+                .size()).isEqualTo(2);
+        assertThat(
+                updatedProject.getReleaseDeploymentPipelines().get(0).getName())
+                        .isEqualTo("some pipeline");
+        assertThat(
+                updatedProject.getReleaseDeploymentPipelines().get(1).getName())
+                        .isEqualTo("some pipeline 2");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT1");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(1)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT2");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(1)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+    }
+
+    @Test
+    public void whenUpdateReleaseDeploymentPipelinesWithRemovedPipeline_thenRemoveExcludedPipeline() {
+
+        // Set up initial Project Entity
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity uatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT1")
+                .pipeline(releaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat1").build();
+
+        releaseDeploymentPipelineEntity.getEnvironments()
+                .add(uatReleaseDeploymentEnvironmentEntity);
+
+        ReleaseDeploymentPipelineEntity releaseDeploymentPipelineEntity2 = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("2")
+                .environments(new ArrayList<>())
+                .name("some pipeline 2")
+                .tag("tag 2")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity uatReleaseDeploymentEnvironmentEntity2 = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT2")
+                .pipeline(releaseDeploymentPipelineEntity2)
+                .positionInPipeline(1)
+                .postfix("uat2").build();
+
+        releaseDeploymentPipelineEntity2.getEnvironments()
+                .add(uatReleaseDeploymentEnvironmentEntity2);
+
+        TenantEntity tenantEntity = TenantEntity.builder().tenantId("2")
+                .name("tenant").description("tenant desc").build();
+        ProjectEntity projectEntity = ProjectEntity.builder().projectId("1")
+                .applications(new HashSet<>())
+                .description("a project").name("Project 1")
+                .owningTenant(tenantEntity)
+                .releaseDeploymentPipelines(new ArrayList<>())
+                .build();
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity);
+        projectEntity.getReleaseDeploymentPipelines()
+                .add(releaseDeploymentPipelineEntity2);
+
+        // Mock find response
+        Mockito.when(projectRepository.findByProjectId("1"))
+                .thenReturn(projectEntity);
+
+        // Setup new release deployment pipeline
+        ReleaseDeploymentPipelineEntity updatedReleaseDeploymentPipelineEntity = ReleaseDeploymentPipelineEntity
+                .builder()
+                .pipelineId("1")
+                .environments(new ArrayList<>())
+                .name("some pipeline")
+                .tag("tag")
+                .build();
+
+        ReleaseDeploymentEnvironmentEntity updatedUatReleaseDeploymentEnvironmentEntity = ReleaseDeploymentEnvironmentEntity
+                .builder()
+                .displayName("UAT1")
+                .pipeline(updatedReleaseDeploymentPipelineEntity)
+                .positionInPipeline(1)
+                .postfix("uat1").build();
+
+        updatedReleaseDeploymentPipelineEntity.getEnvironments()
+                .add(updatedUatReleaseDeploymentEnvironmentEntity);
+
+        ProjectEntity updatedProject = this.projectPersistenceHandler
+                .updateReleaseDeploymentPipelines("1",
+                        Collections.singletonList(
+                                updatedReleaseDeploymentPipelineEntity));
+
+        assertThat(updatedProject.getReleaseDeploymentPipelines()
+                .size()).isEqualTo(1);
+        assertThat(
+                updatedProject.getReleaseDeploymentPipelines().get(0).getName())
+                        .isEqualTo("some pipeline");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .size()).isEqualTo(1);
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getDisplayName()).isEqualTo("UAT1");
+        assertThat(updatedProject.getReleaseDeploymentPipelines().get(0)
+                .getEnvironments()
+                .get(0).getPositionInPipeline()).isEqualTo(1);
+
+    }
+}


### PR DESCRIPTION
This modifies projects to be create-able with no pipelines or environments. The API has then been extended to allow the pipelines to be modified after project creation. When using the PUT endpoint to update pipelines, the entire pipeline definition you want to have needs to be pushed to the API. If a previous pipeline/environment is missing in the new definition, it is deleted. If a new pipeline/environment is present, it is inserted in the position it is defined at. If an old pipeline/environment is changed, they will be updated.

This supports adds support for environmentless projects.

Closes #165 
Closes #161 

