### PR TITLE
Fixing incorrectly named property

### DIFF
--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/AtomistConfigurationProperties.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/AtomistConfigurationProperties.java
@@ -36,7 +36,7 @@ public class AtomistConfigurationProperties {
 
     private String membersAddedToTeamEventUrl;
 
-    private String membersRemovedFromTeamEventUrl;
+    private String memberRemovedFromTeamEventUrl;
 
     private String teamsLinkedToProjectEventUrl;
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/team/TeamAutomationHandler.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/team/TeamAutomationHandler.java
@@ -271,7 +271,7 @@ public class TeamAutomationHandler {
 
         ResponseEntity<String> response = restTemplate.postForEntity(
                 atomistConfigurationProperties
-                        .getMembersRemovedFromTeamEventUrl(),
+                        .getMemberRemovedFromTeamEventUrl(),
                 ingestableObject,
                 String.class);
 


### PR DESCRIPTION
The property name did not match the autogenerated config file property name.

Closes #163 