### PR TITLE
Api resource listing extensions

### DIFF
--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/member/rest/TeamMemberController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/member/rest/TeamMemberController.java
@@ -87,7 +87,8 @@ public class TeamMemberController {
     Resources<TeamMemberResource> list(
             @RequestParam(required = false) String email,
             @RequestParam(required = false) String slackScreenName,
-            @RequestParam(required = false) String teamId) {
+            @RequestParam(required = false) String teamId,
+            @RequestParam(required = false) String domainUsername) {
         List<TeamMemberResource> members = new ArrayList<>();
 
         // TODO see if we can't use that functional library for Java that has pattern matching?
@@ -111,6 +112,12 @@ public class TeamMemberController {
                             .map(assembler::toResource)
                             .collect(Collectors.toList()));
         }
+        else if (StringUtils.isNotBlank(domainUsername)) {
+            members.add(assembler.toResource(
+                    teamMemberService.getTeamMemberPersistenceHandler()
+                            .findByDomainUsernameWithOrWithoutDomain(
+                                    domainUsername)));
+        }
         else if (StringUtils.isAllBlank(email, slackScreenName)) {
             members.addAll(teamMemberService.getTeamMemberPersistenceHandler()
                     .findAll().stream()
@@ -120,7 +127,7 @@ public class TeamMemberController {
         return new Resources<>(members,
                 linkTo(TeamMemberController.class).withRel("self"),
                 linkTo(methodOn(TeamMemberController.class).list(email,
-                        slackScreenName, teamId))
+                        slackScreenName, teamId, domainUsername))
                                 .withRel("self"));
     }
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamController.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/adapter/team/rest/TeamController.java
@@ -137,7 +137,8 @@ public class TeamController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String slackScreenName,
             @RequestParam(required = false) String slackTeamChannel,
-            @RequestParam(required = false) String projectId) {
+            @RequestParam(required = false) String projectId,
+            @RequestParam(required = false) String memberId) {
         Set<TeamResource> teams = new HashSet<>();
 
         // TODO see if we can't use that functional library for Java that has pattern matching?
@@ -150,6 +151,13 @@ public class TeamController {
             teams.addAll(teamService.getPersistenceHandler()
                     .findByMemberOrOwnerSlackScreenName(
                             slackScreenName)
+                    .stream()
+                    .map(assembler::toResource).collect(Collectors.toList()));
+        }
+        else if (StringUtils.isNotBlank(memberId)) {
+            teams.addAll(teamService.getPersistenceHandler()
+                    .findByMemberOrOwnerMemberId(
+                            memberId)
                     .stream()
                     .map(assembler::toResource).collect(Collectors.toList()));
         }
@@ -174,7 +182,7 @@ public class TeamController {
         return new Resources<>(teams,
                 linkTo(TeamController.class).withRel("self"),
                 linkTo(methodOn(TeamController.class).list(name,
-                        slackScreenName, slackTeamChannel, projectId))
+                        slackScreenName, slackTeamChannel, projectId, memberId))
                                 .withRel("self"));
     }
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberPersistenceHandler.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberPersistenceHandler.java
@@ -71,6 +71,20 @@ public class TeamMemberPersistenceHandler {
     }
 
     @Transactional(readOnly = true)
+    public TeamMemberEntity findByDomainUsernameWithOrWithoutDomain(
+            String domainUsername) {
+        TeamMemberEntity entity = null;
+        if (!domainUsername.contains("\\")) {
+            entity = teamMemberRepository
+                    .findByDomainUsernameLike("\\" + domainUsername);
+        }
+        if (entity == null) {
+            entity = teamMemberRepository.findByDomainUsername(domainUsername);
+        }
+        return entity;
+    }
+
+    @Transactional(readOnly = true)
     public List<TeamMemberEntity> findAll() {
         return teamMemberRepository.findAll();
     }

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberPersistenceHandler.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberPersistenceHandler.java
@@ -76,7 +76,7 @@ public class TeamMemberPersistenceHandler {
         TeamMemberEntity entity = null;
         if (!domainUsername.contains("\\")) {
             entity = teamMemberRepository
-                    .findByDomainUsernameLike("\\" + domainUsername);
+                    .findByDomainUsernameEndingWith("\\" + domainUsername);
         }
         if (entity == null) {
             entity = teamMemberRepository.findByDomainUsername(domainUsername);

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberRepository.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberRepository.java
@@ -15,7 +15,7 @@ public interface TeamMemberRepository
 
     TeamMemberEntity findByDomainUsername(String domainUsername);
 
-    TeamMemberEntity findByDomainUsernameLike(String domainUsername);
+    TeamMemberEntity findByDomainUsernameEndingWith(String domainUsername);
 
     List<TeamMemberEntity> findByTeams_TeamId(String teamId);
 

--- a/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberRepository.java
+++ b/nucleus/src/main/java/za/co/absa/subatomic/infrastructure/member/view/jpa/TeamMemberRepository.java
@@ -15,6 +15,8 @@ public interface TeamMemberRepository
 
     TeamMemberEntity findByDomainUsername(String domainUsername);
 
+    TeamMemberEntity findByDomainUsernameLike(String domainUsername);
+
     List<TeamMemberEntity> findByTeams_TeamId(String teamId);
 
     List<TeamMemberEntity> findByMemberIdIn(List<String> memberIds);


### PR DESCRIPTION
Added small query extensions that improve the query functionalities for applications that are not slack name based. I.E. When applications want to query using domain usernames instead of slack names.